### PR TITLE
fix: dbal configuration no longer fails due to missing array keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "patchlevel/event-sourcing": "^3.5",
-        "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^9.28|^10.0|^11.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "patchlevel/event-sourcing": "^3.5",
-        "illuminate/contracts": "^9.28|^10.0|^11.0"
+        "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -213,11 +213,12 @@ class EventSourcingServiceProvider extends ServiceProvider
             return DriverManager::getConnection(
                 [
                     'driver' => $driver,
-                    'dbname' => $connectionParams['database'],
-                    'user' => $connectionParams['username'],
-                    'password' => $connectionParams['password'],
-                    'host' => $connectionParams['host'],
-                    'port' => $connectionParams['port'],
+                    'dbname' => $connectionParams['database'] ?? null,
+                    'path' => $connectionParams['database'] ?? null,
+                    'user' => $connectionParams['username'] ?? null,
+                    'password' => $connectionParams['password'] ?? null,
+                    'host' => $connectionParams['host'] ?? null,
+                    'port' => $connectionParams['port'] ?? null,
                 ],
             );
         });


### PR DESCRIPTION
This PR introduces two fixes to the DBAL configuration:

1. Values are null coalesced to `null` if the referenced keys are not set.
2. The `path` key is now set to the Laravel `database` key, which is utilized for SQLITE.