### PR TITLE
README: Install the latest stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ for [event-sourcing](https://github.com/patchlevel/event-sourcing) library.
 ## Installation
 
 ```bash
-composer require patchlevel/laravel-event-sourcing=1.0.0-beta3
+composer require patchlevel/laravel-event-sourcing
 ```
 
 > [!TIP]


### PR DESCRIPTION
since `1.1.0` is released already we can remove the version pin from the install instructions